### PR TITLE
Change to directory first

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "`dirname $0`"
+
 ROOT=`pwd`
 
 if [ -e config.yml ] ; then


### PR DESCRIPTION
The script is dependent on being in the right directory when it starts, due to the ROOT=`pwd` and later cd $ROOT, so if I started it from the wrong directory it would fail to run runtests.

Simple one line to get you to the right folder no matter how you ran it